### PR TITLE
bug fix for client put; specify result type for std::accumulate

### DIFF
--- a/src/client/put.cpp
+++ b/src/client/put.cpp
@@ -219,7 +219,7 @@ extern "C" yk_return_t yk_put_packed(yk_database_handle_t dbh,
                                       std::accumulate(vsizes, vsizes+count, (size_t)0) };
     margo_instance_id mid = dbh->client->mid;
 
-    size_t total_size = std::accumulate(sizes.begin(), sizes.end(), 0);
+    size_t total_size = std::accumulate(sizes.begin(), sizes.end(), (size_t)0);
 
     if(sizes[2] == 0)
         return YOKAN_ERR_INVALID_ARGS;


### PR DESCRIPTION
The missing `(size_t)` causes an overflow as shown below: 

```
val_sizes = np.array([218316818, 112109581, 218316818, 112109581, 112109581, 112109581, 218316818, 112109581, 218316818, 112109581, 94900818, 104371834, 95189230, 102388470, 95997006, 111366814, 112109581, 112109581, 104930262, 113917026]).sum()
key_sizes = np.array([187, 186, 187, 186, 176, 176, 187, 186, 187, 186, 187, 187, 187, 187, 187, 187, 176, 176, 187, 187]).sum()
total_size = val_sizes+key_sizes+8*20+8*20
print('val_sizes: ', val_sizes)
print('key-sizes: ', key_sizes)
print('total_size: ', total_size)
print('total_size as int32: ', np.int32(total_size))
```
gives the outputs:
```
val_sizes:  2593205380
key-sizes:  3692
total_size:  2593209392
total_size as int32:  -1701757904
```
The compiler is specializing that the call to std::accumulate to the types `size_t, int` and `int` on this machine is 32 bit:
```
-bash-4.2$ ./a.out
Size of int: 4 bytes
Size of long: 8 bytes
Size of ulong: 8 bytes
Size of size_t: 8 bytes
```