### PR TITLE
making github workflow use a cache

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -33,33 +33,42 @@ jobs:
 
     - name: Find external packages
       run: |
-        spack -e . external find --not-buildable cmake
-        spack -e . external find --not-buildable perl
-        spack -e . external find --not-buildable python
-        spack -e . external find --not-buildable mpich
+        spack --color always -e . external find --not-buildable cmake
+        spack --color always -e . external find --not-buildable perl
+        spack --color always -e . external find --not-buildable python
+        spack --color always -e . external find --not-buildable mpich
+        spack --color always -e . external find --not-buildable m4
+        spack --color always -e . external find --not-buildable libtool
+        spack --color always -e . external find --not-buildable autoconf
+        spack --color always -e . external find --not-buildable automake
+        spack --color always -e . external find --not-buildable pkg-config
 
     - name: Add mochi-spack-packages
       run: |
         git clone https://github.com/mochi-hpc/mochi-spack-packages /opt/spack/mochi-spack-packages
-        spack -e . repo add /opt/spack/mochi-spack-packages
+        spack --color always -e . repo add /opt/spack/mochi-spack-packages
 
     - name: Concretize spack environment
       run: |
-        spack -e . concretize -f
+        spack --color always -e . concretize -f
+
+    - name: Create cache key from environment file
+      run: |
+        jq --sort-keys 'del(.spack.commit) | del(.roots)' tests/spack.lock > key.json
 
     - name: Restore Spack cache
       uses: actions/cache@v2
       with:
         path: ~/.spack-ci
-        key: spack-${{ hashFiles('spack.lock') }}
+        key: spack-${{ hashFiles('key.json') }}
 
     - name: Install spack environment
       run: |
-        spack -e . install
+        spack --color always -e . install
 
     - name: Show spack-installed packages for debugging
       run: |
-        spack -e . find -dlv
+        spack --color always -e . find -dlv
 
     - name: Build code and run unit tests
       run: |

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -38,9 +38,18 @@ jobs:
         git clone https://github.com/mochi-hpc/mochi-spack-packages /opt/spack/mochi-spack-packages
         spack -e . repo add /opt/spack/mochi-spack-packages
 
-    - name: Install spack environment
+    - name: Concretize spack environment
       run: |
         spack -e . concretize -f
+
+    - name: Restore Spack cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.spack-ci
+        key: spack-${{ hashFiles('spack.lock') }}
+
+    - name: Install spack environment
+      run: |
         spack -e . install
 
     - name: Show spack-installed packages for debugging

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -33,24 +33,24 @@ jobs:
 
     - name: Find external packages
       run: |
-        spack --color always -e . external find --not-buildable cmake
-        spack --color always -e . external find --not-buildable perl
-        spack --color always -e . external find --not-buildable python
-        spack --color always -e . external find --not-buildable mpich
-        spack --color always -e . external find --not-buildable m4
-        spack --color always -e . external find --not-buildable libtool
-        spack --color always -e . external find --not-buildable autoconf
-        spack --color always -e . external find --not-buildable automake
-        spack --color always -e . external find --not-buildable pkg-config
+        spack --color always -e tests external find --not-buildable cmake
+        spack --color always -e tests external find --not-buildable perl
+        spack --color always -e tests external find --not-buildable python
+        spack --color always -e tests external find --not-buildable mpich
+        spack --color always -e tests external find --not-buildable m4
+        spack --color always -e tests external find --not-buildable libtool
+        spack --color always -e tests external find --not-buildable autoconf
+        spack --color always -e tests external find --not-buildable automake
+        spack --color always -e tests external find --not-buildable pkg-config
 
     - name: Add mochi-spack-packages
       run: |
         git clone https://github.com/mochi-hpc/mochi-spack-packages /opt/spack/mochi-spack-packages
-        spack --color always -e . repo add /opt/spack/mochi-spack-packages
+        spack --color always -e tests repo add /opt/spack/mochi-spack-packages
 
     - name: Concretize spack environment
       run: |
-        spack --color always -e . concretize -f
+        spack --color always -e tests concretize -f
 
     - name: Create cache key from environment file
       run: |
@@ -64,15 +64,15 @@ jobs:
 
     - name: Install spack environment
       run: |
-        spack --color always -e . install
+        spack --color always -e tests install
 
     - name: Show spack-installed packages for debugging
       run: |
-        spack --color always -e . find -dlv
+        spack --color always -e tests find -dlv
 
     - name: Build code and run unit tests
       run: |
-        eval `spack env activate --sh .` &&
+        eval `spack env activate --sh tests` &&
         mkdir build && cd build &&
         cmake .. -DENABLE_COVERAGE=ON \
                  -DENABLE_TESTS=ON \

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -27,11 +27,16 @@ jobs:
         os: ubuntu-20.04
         ref: develop
 
+    - name: Install mpich
+      run: |
+        sudo apt install -y libmpich-dev
+
     - name: Find external packages
       run: |
         spack -e . external find --not-buildable cmake
         spack -e . external find --not-buildable perl
         spack -e . external find --not-buildable python
+        spack -e . external find --not-buildable mpich
 
     - name: Add mochi-spack-packages
       run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,11 +57,11 @@ jobs:
       run: |
         jq --sort-keys 'del(.spack.commit) | del(.roots)' tests/spack.lock > key.json
 
-     - name: Restore Spack cache
-       uses: actions/cache@v2
-       with:
-         path: ~/.spack-ci
-         key: spack-${{ hashFiles('key.json') }}
+    - name: Restore Spack cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.spack-ci
+        key: spack-${{ hashFiles('key.json') }}
 
     - name: Install spack environment
       run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,24 +34,24 @@ jobs:
 
     - name: Find external packages
       run: |
-        spack --color always -e . external find --not-buildable cmake
-        spack --color always -e . external find --not-buildable perl
-        spack --color always -e . external find --not-buildable python
-        spack --color always -e . external find --not-buildable mpich
-        spack --color always -e . external find --not-buildable m4
-        spack --color always -e . external find --not-buildable libtool
-        spack --color always -e . external find --not-buildable autoconf
-        spack --color always -e . external find --not-buildable automake
-        spack --color always -e . external find --not-buildable pkg-config
+        spack --color always -e tests external find --not-buildable cmake
+        spack --color always -e tests external find --not-buildable perl
+        spack --color always -e tests external find --not-buildable python
+        spack --color always -e tests external find --not-buildable mpich
+        spack --color always -e tests external find --not-buildable m4
+        spack --color always -e tests external find --not-buildable libtool
+        spack --color always -e tests external find --not-buildable autoconf
+        spack --color always -e tests external find --not-buildable automake
+        spack --color always -e tests external find --not-buildable pkg-config
 
     - name: Add mochi-spack-packages
       run: |
         git clone https://github.com/mochi-hpc/mochi-spack-packages /opt/spack/mochi-spack-packages
-        spack spack --color always -e . repo add /opt/spack/mochi-spack-packages
+        spack --color always -e tests repo add /opt/spack/mochi-spack-packages
 
     - name: Concretize spack environment
       run: |
-        spack --color always -e . concretize -f
+        spack --color always -e tests concretize -f
 
     - name: Create cache key from environment file
       run: |
@@ -65,11 +65,11 @@ jobs:
 
     - name: Install spack environment
       run: |
-        spack --color always -e . install
+        spack --color always -e tests install
 
     - name: Show spack-installed packages for debugging
       run: |
-        spack --color always -e . find -dlv
+        spack --color always -e tests find -dlv
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
@@ -79,7 +79,7 @@ jobs:
 
     - name: Build code and run unit tests
       run: |
-        eval `spack env activate --sh .` &&
+        eval `spack env activate --sh tests` &&
         mkdir build && cd build &&
         cmake .. -DENABLE_TESTS=ON \
                  -DCMAKE_BUILD_TYPE=Debug \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,23 +34,42 @@ jobs:
 
     - name: Find external packages
       run: |
-        spack -e . external find --not-buildable cmake
-        spack -e . external find --not-buildable perl
-        spack -e . external find --not-buildable python
+        spack --color always -e . external find --not-buildable cmake
+        spack --color always -e . external find --not-buildable perl
+        spack --color always -e . external find --not-buildable python
+        spack --color always -e . external find --not-buildable mpich
+        spack --color always -e . external find --not-buildable m4
+        spack --color always -e . external find --not-buildable libtool
+        spack --color always -e . external find --not-buildable autoconf
+        spack --color always -e . external find --not-buildable automake
+        spack --color always -e . external find --not-buildable pkg-config
 
     - name: Add mochi-spack-packages
       run: |
         git clone https://github.com/mochi-hpc/mochi-spack-packages /opt/spack/mochi-spack-packages
-        spack -e . repo add /opt/spack/mochi-spack-packages
+        spack spack --color always -e . repo add /opt/spack/mochi-spack-packages
+
+    - name: Concretize spack environment
+      run: |
+        spack --color always -e . concretize -f
+
+    - name: Create cache key from environment file
+      run: |
+        jq --sort-keys 'del(.spack.commit) | del(.roots)' tests/spack.lock > key.json
+
+     - name: Restore Spack cache
+       uses: actions/cache@v2
+       with:
+         path: ~/.spack-ci
+         key: spack-${{ hashFiles('key.json') }}
 
     - name: Install spack environment
       run: |
-        spack -e . concretize -f
-        spack -e . install
+        spack --color always -e . install
 
     - name: Show spack-installed packages for debugging
       run: |
-        spack -e . find -dlv
+        spack --color always -e . find -dlv
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,33 +33,42 @@ jobs:
 
     - name: Find external packages
       run: |
-        spack -e . external find --not-buildable cmake
-        spack -e . external find --not-buildable perl
-        spack -e . external find --not-buildable python
-        spack -e . external find --not-buildable mpich
+        spack --color always -e . external find --not-buildable cmake
+        spack --color always -e . external find --not-buildable perl
+        spack --color always -e . external find --not-buildable python
+        spack --color always -e . external find --not-buildable mpich
+        spack --color always -e . external find --not-buildable m4
+        spack --color always -e . external find --not-buildable libtool
+        spack --color always -e . external find --not-buildable autoconf
+        spack --color always -e . external find --not-buildable automake
+        spack --color always -e . external find --not-buildable pkg-config
 
     - name: Add mochi-spack-packages
       run: |
         git clone https://github.com/mochi-hpc/mochi-spack-packages /opt/spack/mochi-spack-packages
-        spack -e . repo add /opt/spack/mochi-spack-packages
+        spack --color always -e . repo add /opt/spack/mochi-spack-packages
 
     - name: Concretizing spack environment
       run: |
-        spack -e . concretize -f
+        spack --color always -e . concretize -f
+
+    - name: Create cache key from environment file
+      run: |
+        jq --sort-keys 'del(.spack.commit) | del(.roots)' tests/spack.lock > key.json
 
     - name: Restore Spack cache
       uses: actions/cache@v2
       with:
         path: ~/.spack-ci
-        key: spack-${{ hashFiles('spack.lock') }}
+        key: spack-${{ hashFiles('key.json') }}
 
     - name: Installing spack environment
       run: |
-        spack -e . install
+        spack --color always -e . install
 
     - name: Show spack-installed packages for debugging
       run: |
-        spack -e . find -dlv
+        spack --color always -e . find -dlv
 
     - name: Build code and run unit tests
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,24 +33,24 @@ jobs:
 
     - name: Find external packages
       run: |
-        spack --color always -e . external find --not-buildable cmake
-        spack --color always -e . external find --not-buildable perl
-        spack --color always -e . external find --not-buildable python
-        spack --color always -e . external find --not-buildable mpich
-        spack --color always -e . external find --not-buildable m4
-        spack --color always -e . external find --not-buildable libtool
-        spack --color always -e . external find --not-buildable autoconf
-        spack --color always -e . external find --not-buildable automake
-        spack --color always -e . external find --not-buildable pkg-config
+        spack --color always -e tests external find --not-buildable cmake
+        spack --color always -e tests external find --not-buildable perl
+        spack --color always -e tests external find --not-buildable python
+        spack --color always -e tests external find --not-buildable mpich
+        spack --color always -e tests external find --not-buildable m4
+        spack --color always -e tests external find --not-buildable libtool
+        spack --color always -e tests external find --not-buildable autoconf
+        spack --color always -e tests external find --not-buildable automake
+        spack --color always -e tests external find --not-buildable pkg-config
 
     - name: Add mochi-spack-packages
       run: |
         git clone https://github.com/mochi-hpc/mochi-spack-packages /opt/spack/mochi-spack-packages
-        spack --color always -e . repo add /opt/spack/mochi-spack-packages
+        spack --color always -e tests repo add /opt/spack/mochi-spack-packages
 
     - name: Concretizing spack environment
       run: |
-        spack --color always -e . concretize -f
+        spack --color always -e tests concretize -f
 
     - name: Create cache key from environment file
       run: |
@@ -64,15 +64,15 @@ jobs:
 
     - name: Installing spack environment
       run: |
-        spack --color always -e . install
+        spack --color always -e tests install
 
     - name: Show spack-installed packages for debugging
       run: |
-        spack --color always -e . find -dlv
+        spack --color always -e tests find -dlv
 
     - name: Build code and run unit tests
       run: |
-        eval `spack env activate --sh .` &&
+        eval `spack env activate --sh tests` &&
         mkdir build && cd build &&
         cmake .. -DENABLE_TESTS=ON \
                  -DCMAKE_BUILD_TYPE=Debug \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,11 +27,16 @@ jobs:
         os: ubuntu-20.04
         ref: develop
 
+    - name: Install mpich
+      run: |
+        sudo apt install -y libmpich-dev
+
     - name: Find external packages
       run: |
         spack -e . external find --not-buildable cmake
         spack -e . external find --not-buildable perl
         spack -e . external find --not-buildable python
+        spack -e . external find --not-buildable mpich
 
     - name: Add mochi-spack-packages
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,18 @@ jobs:
         git clone https://github.com/mochi-hpc/mochi-spack-packages /opt/spack/mochi-spack-packages
         spack -e . repo add /opt/spack/mochi-spack-packages
 
-    - name: Install spack environment
+    - name: Concretizing spack environment
       run: |
         spack -e . concretize -f
+
+    - name: Restore Spack cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.spack-ci
+        key: spack-${{ hashFiles('spack.lock') }}
+
+    - name: Installing spack environment
+      run: |
         spack -e . install
 
     - name: Show spack-installed packages for debugging

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
   - mochi-margo
   - mercury ~boostsys ^libfabric fabrics=tcp,rxm
   - py-mochi-margo
-  - mochi-bedrock
+  - mochi-bedrock ^mpich
   - ycsb-cpp-interface ^ycsb@master
   - rocksdb+rtti
   - mochi-remi@0.3.3:+bedrock

--- a/tests/spack.yaml
+++ b/tests/spack.yaml
@@ -1,0 +1,36 @@
+spack:
+  specs:
+  - cmake
+  - pkg-config
+  - mpi
+  - uuid
+  - nlohmann-json
+  - tclap
+  - lua-sol2
+  - leveldb@1.22
+  - berkeley-db+cxx+stl
+  - tkrzw
+  - gdbm
+  - lmdb
+  - unqlite@master
+  - py-pybind11
+  - mochi-margo
+  - mercury ~boostsys ^libfabric fabrics=tcp,rxm
+  - py-mochi-margo
+  - mochi-bedrock ^mpich
+  - ycsb-cpp-interface ^ycsb@master
+  - rocksdb+rtti
+  - mochi-remi@0.3.3:+bedrock
+  concretizer:
+    unify: true
+    reuse: true
+  modules:
+    prefix_inspections:
+      lib: [LD_LIBRARY_PATH]
+      lib64: [LD_LIBRARY_PATH]
+  config:
+    source_cache: ~/.spack-ci/source_cache
+    misc_cache: ~/.spack-ci/misc_cache
+    test_cache: ~/.spack-ci/test_cache
+    install_tree:
+      root: ~/.spack-ci/install

--- a/tests/spack.yaml
+++ b/tests/spack.yaml
@@ -1,3 +1,8 @@
+# This file defines the spack environment used by github actions
+# (tests, codeql, and codecov) when building and testing the code.
+# In particular the "config" field sets the installation path and
+# spack caches to ~/.spack-ci so that they can be retrieved using
+# the github cache action across runs.
 spack:
   specs:
   - cmake


### PR DESCRIPTION
This PR improves the github workflows to make builds reuse a cached spack installation.